### PR TITLE
feat(log): redis stream hook + kratos.go cosmetic/Sync bug fixes

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -15,3 +15,76 @@
 - Create DingDing group
 - Add Group Assistant(Custom robot)
 - Get Webhook url as URL
+
+## Redis Stream Hook
+
+Producer-side core that XADDs each log entry into a Redis stream. Designed
+for cross-service runtime event aggregation (e.g., a system_log table where
+N services produce and a single consumer persists). The hook builds its own
+`redis.UniversalClient` from `RedisStreamConfig` — no external client
+required.
+
+```go
+import (
+    tlog "github.com/hkjojo/go-toolkits/log/v2"
+    "github.com/hkjojo/go-toolkits/log/v2/hook"
+)
+
+cfg := &tlog.Config{
+    Level:  "info",
+    Format: "json",
+    Caller: true,
+    Fields: map[string]string{"service": "maker-adapter"},
+    Redis: &hook.RedisStreamConfig{
+        Addr:      "redis:6379",
+        StreamKey: "system_logs",
+        MaxLen:    200_000,
+        QPS:       50,
+        // Filter is the BaseCore drop list — listed field keys are removed
+        // before serialization (e.g., to keep secrets out of logs).
+        CoreConfig: hook.CoreConfig{
+            Filter: []string{"password", "api_key", "secret"},
+        },
+    },
+}
+logger, _ := tlog.New(cfg)
+```
+
+Each XADD writes the following fields:
+
+| Field     | Source                                             |
+|-----------|----------------------------------------------------|
+| `ts`      | unix milliseconds (string)                         |
+| `level`   | zap raw level (`debug`/`info`/`warn`/`error`/...)  |
+| `service` | `RedisStreamConfig.Fields["service"]`              |
+| `source`  | sub-logger field via `log.With("source", "...")`   |
+| `msg`     | zap entry message                                  |
+| `payload` | remaining structured fields, JSON-encoded          |
+| `host`    | `os.Hostname()` (auto-injected)                    |
+
+Consumer side (parses the same wire format and feeds a user-provided
+`SaverFunc` for batch persistence):
+
+```go
+consumer, _ := hook.NewRedisStreamConsumer(cfg.Redis, hook.ConsumerOpts{
+    GroupName:  "system-log-persister",
+    ConsumerID: "apiserver-" + os.Getenv("HOSTNAME"),
+}, func(ctx context.Context, batch []hook.Entry) error {
+    return repo.BulkInsertSystemLog(ctx, batch)
+})
+_ = consumer.Start(ctx)
+defer consumer.Stop()
+```
+
+The consumer runs three internal goroutines:
+
+1. main loop — `XReadGroup` + saver + `XAck`
+2. autoclaim loop — periodic `XAutoClaim` of stale PEL entries
+3. cleanup loop — periodic `XGroupDelConsumer` for idle consumers
+
+Failure modes:
+
+- redis ping fail at startup → stderr warning, core continues, sink degrades silently
+- saver returns error → batch left in PEL, reclaimed on next autoclaim cycle
+- producer storm → token-bucket throttle (`QPS`) drops over-budget entries; observable via `(*RedisStreamCore).DroppedTotal()`
+- oversized payload → replaced with `{"_truncated":true}` (cap via `MaxPayloadBytes`)

--- a/log/go.mod
+++ b/log/go.mod
@@ -19,9 +19,12 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.0.2 // indirect
 	github.com/DataDog/gostackparse v0.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
@@ -43,17 +46,19 @@ require (
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tebeka/strftime v0.1.3 // indirect
 	github.com/urfave/cli/v2 v2.23.5 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.26.0 // indirect
 	go.opentelemetry.io/otel/metric v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
-	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/log/go.sum
+++ b/log/go.sum
@@ -15,11 +15,15 @@ github.com/Shopify/sarama v1.26.1/go.mod h1:NbSGBSSndYaIhRcBtY9V0U7AyH+x71bG668A
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -35,6 +39,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
@@ -154,6 +160,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 h1:dY6ETXrvDG7Sa4vE8ZQG4yqWg6UnOcbqTAahkV813vQ=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -184,6 +192,8 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/otel v1.7.0/go.mod h1:5BdUoMIz5WEs0vt0CUEMtSSaTSHBBVwrhnz7+nrD5xk=
 go.opentelemetry.io/otel v1.26.0 h1:LQwgL5s/1W7YiiRwxf03QGnWLb2HW4pLiAhaA5cZXBs=
 go.opentelemetry.io/otel v1.26.0/go.mod h1:UmLkJHUAidDval2EICqBMbnAd0/m2vmpf/dAM+fvFs4=
@@ -204,6 +214,8 @@ go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IO
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=

--- a/log/hook/redis.go
+++ b/log/hook/redis.go
@@ -1,0 +1,301 @@
+package hook
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// RedisStreamConfig configures a zap core that XADDs each log entry into a
+// Redis stream. Used for cross-service runtime event aggregation (system_log).
+//
+// The XADD entry shape is fixed per the ADR-0042 contract — consumer side
+// (NewRedisStreamConsumer / RedisStreamConsumer) parses these exact fields:
+//
+//	ts        unix milliseconds (string)
+//	level     zap raw level string (debug/info/warn/error/dpanic/panic/fatal)
+//	service   process identity (from CoreConfig.Fields["service"])
+//	source    sub-component name (from log.With("source", ...) sub-logger)
+//	msg       zap entry.Message (machine-readable, snake_case)
+//	payload   remaining structured fields, JSON-encoded
+//	host      os.Hostname() (auto-injected at core construction; multi-replica dedup)
+type RedisStreamConfig struct {
+	CoreConfig `json:",inline"`
+
+	// Redis connection — hkjojo internally builds a redis.UniversalClient from these.
+	Addr     string `json:"addr"`
+	Password string `json:"password"`
+	DB       int    `json:"db"`
+	UseTLS   bool   `json:"use_tls"`
+
+	// Stream behavior.
+	StreamKey       string `json:"stream_key"`        // default "system_logs"
+	MaxLen          int64  `json:"max_len"`           // default 200_000 (approximate)
+	BatchSize       int    `json:"batch_size"`        // reserved for future batching; current impl is single-write
+	FlushMs         int    `json:"flush_ms"`          // reserved for future batching
+	QPS             int    `json:"qps"`               // 0 = unlimited; default 50
+	MaxPayloadBytes int    `json:"max_payload_bytes"` // default 4096; oversized payload replaced with {"_truncated":true}
+}
+
+// RedisStreamCore is a zapcore.Core that ships log entries to a Redis stream.
+//
+// It composes hkjojo BaseCore (queue / filter / fields / level / off) and
+// implements the writeData callback to serialize a CoreData into an XADD.
+// The redis.UniversalClient is built internally from RedisStreamConfig and is
+// owned by this core (independent from any business-side redis client).
+//
+// Failure modes (matching hook/kafka.go semantics — non-blocking, log-and-drop):
+//   - Constructor: redis.Ping failure prints to stderr but does not error;
+//     the core continues and individual XADDs may also fail at write time.
+//   - writeData: XADD failure prints to stderr; the entry is dropped.
+//     stdout/file paths are unaffected (zap tee runs cores independently).
+//   - Producer storm: token bucket (RedisStreamConfig.QPS) drops over-budget
+//     entries and increments droppedTotal — observable via DroppedTotal().
+type RedisStreamCore struct {
+	*BaseCore
+
+	cfg    *RedisStreamConfig
+	client redis.UniversalClient
+	host   string
+
+	// Token bucket state — atomic to avoid taking a lock in writeData hot path.
+	bucketTokens   atomic.Int64
+	bucketLastRefill atomic.Int64 // unix nanoseconds
+	bucketCap      int64
+	droppedTotal   atomic.Uint64
+}
+
+// NewRedisStreamCore constructs a RedisStreamCore. The returned core is ready
+// to be tee'd onto a zap.Logger via zapcore.NewTee, or appended to the cores
+// list inside tklog.New (which RedisStreamConfig is wired into via the main
+// Config.Redis field).
+//
+// Defaults applied for unset fields:
+//   - StreamKey:       "system_logs"
+//   - MaxLen:          200_000
+//   - QPS:             50 (0 explicitly disables throttle)
+//   - MaxPayloadBytes: 4096
+//   - QueueLength:     1024 (BaseCore async buffer)
+//
+// `prefix` and `fields` follow the same convention as NewKafkaCore — fields
+// are merged into BaseCore.fields and emitted as always-on tags on every
+// entry. The "service" tag is read from this map at writeData time.
+func NewRedisStreamCore(cfg *RedisStreamConfig, prefix string, fields map[string]string, encode zapcore.EncoderConfig) (*RedisStreamCore, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("redis stream core: nil config")
+	}
+	if cfg.Addr == "" {
+		return nil, fmt.Errorf("redis stream core: addr is required")
+	}
+
+	applyRedisStreamDefaults(cfg)
+
+	host, _ := os.Hostname()
+
+	core := &RedisStreamCore{
+		BaseCore: &BaseCore{
+			queue:        make(chan *CoreData, cfg.QueueLength),
+			LevelEnabler: zap.NewAtomicLevelAt(ParseLevel(cfg.Level)),
+			enc:          zapcore.NewJSONEncoder(encode),
+			out:          zapcore.AddSync(io.Discard),
+			filters:      getfilters(cfg.Filter),
+			fields:       CombineFields(fields, cfg.Fields),
+			off:          cfg.Off,
+		},
+		cfg:       cfg,
+		host:      host,
+		bucketCap: int64(cfg.QPS),
+	}
+	core.BaseCore.core = core
+
+	if cfg.QPS > 0 {
+		core.bucketTokens.Store(int64(cfg.QPS))
+		core.bucketLastRefill.Store(time.Now().UnixNano())
+	}
+
+	opts := &redis.UniversalOptions{
+		Addrs:    []string{cfg.Addr},
+		Password: cfg.Password,
+		DB:       cfg.DB,
+	}
+	if cfg.UseTLS {
+		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	core.client = redis.NewUniversalClient(opts)
+
+	// Best-effort startup ping. Do not fail core construction — core continues
+	// to the goroutine and writeData errors will print to stderr at runtime.
+	// This matches hook/kafka.go semantics where producer construction errors
+	// also degrade to stderr without aborting the logger.
+	pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := core.client.Ping(pingCtx).Err(); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"[log] redis stream core: ping err (sink may be unavailable): %v\n", err)
+	}
+
+	core.start()
+	return core, nil
+}
+
+// Close releases the underlying redis client. Use during process shutdown
+// after the BaseCore queue has drained.
+func (c *RedisStreamCore) Close() error {
+	if c.client != nil {
+		return c.client.Close()
+	}
+	return nil
+}
+
+// DroppedTotal returns the cumulative count of entries dropped by the token
+// bucket (over-QPS) since core construction. Useful for the
+// system_log_dropped_total metric (consumer can scrape via callback).
+func (c *RedisStreamCore) DroppedTotal() uint64 {
+	return c.droppedTotal.Load()
+}
+
+// writeData runs in the BaseCore goroutine (single consumer of c.queue).
+// It serializes the entry per the ADR-0042 contract and XADDs to the stream.
+// On QPS overrun, it drops the entry and increments droppedTotal — this is
+// the only loss path under healthy redis (the rest is reactive to redis
+// failures, observable in stderr).
+func (c *RedisStreamCore) writeData(data *CoreData) {
+	if !c.allow() {
+		c.droppedTotal.Add(1)
+		return
+	}
+
+	// Extract source from fields (zap.With("source", ...) sub-logger derives
+	// add this field). Hoist to top-level XADD k/v so the consumer can use
+	// it as a primary filter without parsing the payload JSON.
+	source := ""
+	remaining := make([]zapcore.Field, 0, len(data.fields))
+	for _, f := range data.fields {
+		if f.Key == "source" {
+			source = c.getFieldString(f)
+			continue
+		}
+		remaining = append(remaining, f)
+	}
+
+	// Reduce remaining fields into a typed map → JSON. getField preserves
+	// Go-side types (int → int64, float → float64, etc.) so consumers see
+	// unmarshaled JSON numbers, not stringified ints.
+	payloadMap := make(map[string]any, len(remaining))
+	for _, f := range remaining {
+		payloadMap[f.Key] = c.getField(f)
+	}
+	payloadJSON, err := json.Marshal(payloadMap)
+	if err != nil {
+		// JSON encoding failure is rare (only with cyclic graphs / chan / func types).
+		// Replace with truncation marker — keeping the entry in the stream is more
+		// useful than dropping silently.
+		payloadJSON = []byte(`{"_encode_error":true}`)
+	}
+
+	// Hard cap on payload size — defends against accidental request-body or
+	// orderbook dumps in log fields. Replaced (not truncated) because partial
+	// JSON is invalid and would fail consumer-side unmarshal.
+	if c.cfg.MaxPayloadBytes > 0 && len(payloadJSON) > c.cfg.MaxPayloadBytes {
+		payloadJSON = []byte(`{"_truncated":true}`)
+	}
+
+	service := ""
+	if c.fields != nil {
+		service = c.fields["service"]
+	}
+
+	values := map[string]any{
+		"ts":      strconv.FormatInt(data.entry.Time.UnixMilli(), 10),
+		"level":   data.entry.Level.String(),
+		"service": service,
+		"source":  source,
+		"msg":     data.entry.Message,
+		"payload": string(payloadJSON),
+		"host":    c.host,
+	}
+
+	if err := c.client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: c.cfg.StreamKey,
+		MaxLen: c.cfg.MaxLen,
+		Approx: true, // MAXLEN ~ N keeps trim O(1)
+		Values: values,
+	}).Err(); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"[log] redis stream xadd err: %v\n", err)
+	}
+}
+
+// allow consumes one token from the QPS bucket. Returns true if granted,
+// false if over budget. Refills lazily based on elapsed nanoseconds — no
+// background ticker, no lock contention beyond two atomic CAS-equivalents.
+//
+// QPS=0 disables throttling entirely (always returns true).
+func (c *RedisStreamCore) allow() bool {
+	if c.cfg.QPS <= 0 {
+		return true
+	}
+
+	now := time.Now().UnixNano()
+	last := c.bucketLastRefill.Load()
+	elapsed := now - last
+
+	// Compute tokens to refill since last call. One second = full QPS budget.
+	if elapsed > 0 {
+		refill := int64(math.Floor(float64(elapsed) * float64(c.bucketCap) / float64(time.Second)))
+		if refill > 0 && c.bucketLastRefill.CompareAndSwap(last, now) {
+			// Add refill but cap at bucketCap so a long idle window doesn't
+			// allow a single burst > QPS.
+			tokens := c.bucketTokens.Add(refill)
+			if tokens > c.bucketCap {
+				c.bucketTokens.Store(c.bucketCap)
+			}
+		}
+	}
+
+	// Try to consume one token.
+	for {
+		current := c.bucketTokens.Load()
+		if current <= 0 {
+			return false
+		}
+		if c.bucketTokens.CompareAndSwap(current, current-1) {
+			return true
+		}
+	}
+}
+
+func applyRedisStreamDefaults(cfg *RedisStreamConfig) {
+	if cfg.StreamKey == "" {
+		cfg.StreamKey = "system_logs"
+	}
+	if cfg.MaxLen <= 0 {
+		cfg.MaxLen = 200_000
+	}
+	if cfg.QueueLength == 0 {
+		cfg.QueueLength = 1024
+	}
+	if cfg.QPS == 0 {
+		cfg.QPS = 50
+	}
+	if cfg.MaxPayloadBytes <= 0 {
+		cfg.MaxPayloadBytes = 4096
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 100
+	}
+	if cfg.FlushMs <= 0 {
+		cfg.FlushMs = 500
+	}
+}

--- a/log/hook/redis_consumer.go
+++ b/log/hook/redis_consumer.go
@@ -1,0 +1,457 @@
+package hook
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Entry is a parsed log entry consumed from a Redis stream populated by
+// RedisStreamCore. It mirrors the producer-side XADD shape (per ADR-0042).
+//
+// StreamID is the Redis-assigned entry id (e.g., "1746523648123-0"). It is
+// not currently used for idempotency at the schema level (system_log uses
+// at-least-once semantics, INV-SL-003) but is exposed in case savers want
+// to dedup in memory or upgrade to exactly-once at their own discretion.
+type Entry struct {
+	StreamID string
+	Ts       time.Time
+	Service  string
+	Source   string
+	Level    string
+	Msg      string
+	Payload  map[string]any
+	Host     string
+}
+
+// SaverFunc is the consumer-side callback invoked once per batch read from
+// the stream. The saver is responsible for persisting the batch (e.g.,
+// bulk-INSERT into a PG table). Errors are logged and the batch is NOT
+// XACK'd, so the entries remain in PEL and will be reclaimed by the next
+// XAUTOCLAIM cycle.
+type SaverFunc func(ctx context.Context, batch []Entry) error
+
+// ConsumerOpts configures runtime behavior of RedisStreamConsumer. Static
+// fields (StreamKey, redis connection) are pulled from the producer-side
+// RedisStreamConfig so producer and consumer share a single source of truth
+// for the stream contract.
+type ConsumerOpts struct {
+	GroupName  string // required; e.g., "system-log-persister"
+	ConsumerID string // required, must be per-instance unique; e.g., "apiserver-{HOSTNAME}"
+
+	// BatchSize is the COUNT argument to XReadGroup. Default 100.
+	BatchSize int
+
+	// FlushMs is the BLOCK timeout (ms) for XReadGroup. The consumer wakes
+	// up at this cadence even when no entries are available, so callbacks
+	// like context cancellation are honored promptly. Default 500.
+	FlushMs int
+
+	// MinIdleTime is the threshold for XAUTOCLAIM — entries pending in PEL
+	// longer than this duration are reclaimed by other consumers. Default 30s.
+	MinIdleTime time.Duration
+
+	// AutoClaimInterval controls how often the consumer scans for stale PEL
+	// entries to reclaim. Default 10s.
+	AutoClaimInterval time.Duration
+
+	// IdleConsumerTTL is the threshold for XGROUP DELCONSUMER — consumers
+	// idle longer than this are removed from the group (cleanup of pods
+	// that scaled down or restarted with a new ConsumerID). Default 10min.
+	IdleConsumerTTL time.Duration
+
+	// ConsumerCleanupInterval controls how often the offline-consumer
+	// cleanup goroutine runs. Default 5min.
+	ConsumerCleanupInterval time.Duration
+}
+
+// RedisStreamConsumer reads log entries written by RedisStreamCore from a
+// Redis stream, parses them into typed Entry, calls a user-provided
+// SaverFunc for each batch, and XACKs on success.
+//
+// Three goroutines run concurrently after Start:
+//  1. main loop — XReadGroup + saver + XACK
+//  2. autoclaim loop — periodic XAUTOCLAIM for stale PEL entries
+//  3. cleanup loop — periodic XGROUP DELCONSUMER for idle consumers
+//
+// All three honor context cancellation from Start and exit cleanly on Stop.
+type RedisStreamConsumer struct {
+	streamCfg *RedisStreamConfig
+	opts      ConsumerOpts
+	saver     SaverFunc
+
+	client redis.UniversalClient
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	stopped chan struct{}
+	wg      sync.WaitGroup
+}
+
+// NewRedisStreamConsumer constructs a consumer. The redis client is built
+// internally from streamCfg (matching producer-side ownership) so consumer
+// and producer share the same connection contract — connect to the same
+// addr/db/auth as wherever the producer XADDs.
+func NewRedisStreamConsumer(streamCfg *RedisStreamConfig, opts ConsumerOpts, saver SaverFunc) (*RedisStreamConsumer, error) {
+	if streamCfg == nil {
+		return nil, errors.New("redis stream consumer: nil stream config")
+	}
+	if streamCfg.Addr == "" {
+		return nil, errors.New("redis stream consumer: addr is required")
+	}
+	if opts.GroupName == "" {
+		return nil, errors.New("redis stream consumer: group name is required")
+	}
+	if opts.ConsumerID == "" {
+		return nil, errors.New("redis stream consumer: consumer id is required")
+	}
+	if saver == nil {
+		return nil, errors.New("redis stream consumer: saver is required")
+	}
+
+	applyRedisStreamDefaults(streamCfg)
+	applyConsumerOptDefaults(&opts)
+
+	clientOpts := &redis.UniversalOptions{
+		Addrs:    []string{streamCfg.Addr},
+		Password: streamCfg.Password,
+		DB:       streamCfg.DB,
+	}
+	if streamCfg.UseTLS {
+		clientOpts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+
+	c := &RedisStreamConsumer{
+		streamCfg: streamCfg,
+		opts:      opts,
+		saver:     saver,
+		client:    redis.NewUniversalClient(clientOpts),
+		stopped:   make(chan struct{}),
+	}
+	return c, nil
+}
+
+// Start launches the three internal goroutines. The provided ctx is the
+// parent for all of them; cancelling ctx (or calling Stop) terminates the
+// consumer.
+//
+// Start is idempotent in the sense that repeated calls return the prior
+// error if construction succeeded but startup failed; concurrent calls are
+// not supported.
+//
+// XGroupCreateMkStream is invoked once at startup with idempotent semantics
+// (BUSYGROUP error is treated as success — the group already exists from a
+// previous run). The starting ID is "$" so this consumer instance only sees
+// new entries — historical entries already ACK'd by a prior consumer run
+// are not re-fed. (XAUTOCLAIM still picks up unacked entries from the PEL.)
+func (c *RedisStreamConsumer) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cancel != nil {
+		return errors.New("redis stream consumer: already started")
+	}
+
+	if err := c.ensureGroup(ctx); err != nil {
+		return fmt.Errorf("redis stream consumer: ensure group: %w", err)
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+
+	c.wg.Add(3)
+	go c.runMainLoop(loopCtx)
+	go c.runAutoClaimLoop(loopCtx)
+	go c.runConsumerCleanupLoop(loopCtx)
+
+	go func() {
+		c.wg.Wait()
+		close(c.stopped)
+	}()
+
+	return nil
+}
+
+// Stop signals all goroutines to exit, waits for them to drain, and closes
+// the underlying redis client. Safe to call once; subsequent calls return
+// nil immediately.
+func (c *RedisStreamConsumer) Stop() error {
+	c.mu.Lock()
+	if c.cancel == nil {
+		c.mu.Unlock()
+		return nil
+	}
+	cancel := c.cancel
+	c.cancel = nil
+	c.mu.Unlock()
+
+	cancel()
+	<-c.stopped
+
+	if c.client != nil {
+		return c.client.Close()
+	}
+	return nil
+}
+
+func (c *RedisStreamConsumer) ensureGroup(ctx context.Context) error {
+	err := c.client.XGroupCreateMkStream(ctx, c.streamCfg.StreamKey, c.opts.GroupName, "$").Err()
+	if err == nil {
+		return nil
+	}
+	// BUSYGROUP signals "group already exists" — idempotent success.
+	if isBusyGroup(err) {
+		return nil
+	}
+	return err
+}
+
+func (c *RedisStreamConsumer) runMainLoop(ctx context.Context) {
+	defer c.wg.Done()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		res, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    c.opts.GroupName,
+			Consumer: c.opts.ConsumerID,
+			Streams:  []string{c.streamCfg.StreamKey, ">"},
+			Count:    int64(c.opts.BatchSize),
+			Block:    time.Duration(c.opts.FlushMs) * time.Millisecond,
+		}).Result()
+
+		if err != nil {
+			if errors.Is(err, redis.Nil) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			fmt.Fprintf(os.Stderr,
+				"[log] redis stream consumer xreadgroup err: %v\n", err)
+			// Brief sleep so a persistent error (auth failure, server down)
+			// doesn't hot-loop the CPU.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+
+		c.handleStreams(ctx, res)
+	}
+}
+
+func (c *RedisStreamConsumer) handleStreams(ctx context.Context, streams []redis.XStream) {
+	for _, stream := range streams {
+		if len(stream.Messages) == 0 {
+			continue
+		}
+		batch := make([]Entry, 0, len(stream.Messages))
+		ids := make([]string, 0, len(stream.Messages))
+		for _, msg := range stream.Messages {
+			entry, err := parseEntry(msg)
+			if err != nil {
+				// Malformed entries are dropped (NOT ACK'd intentionally —
+				// they will reach PEL and need manual intervention). A
+				// single bad entry should not block the rest of the batch.
+				fmt.Fprintf(os.Stderr,
+					"[log] redis stream consumer parse err id=%s: %v\n", msg.ID, err)
+				continue
+			}
+			batch = append(batch, entry)
+			ids = append(ids, msg.ID)
+		}
+		if len(batch) == 0 {
+			continue
+		}
+		if err := c.saver(ctx, batch); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"[log] redis stream consumer saver err: %v (batch=%d, leaving in PEL)\n",
+				err, len(batch))
+			continue // leave in PEL for autoclaim
+		}
+		if err := c.client.XAck(ctx, c.streamCfg.StreamKey, c.opts.GroupName, ids...).Err(); err != nil {
+			// XAck failure is non-fatal — entries will be redelivered via
+			// XAUTOCLAIM and the saver will land them again (at-least-once,
+			// per ADR-0042 §INV-SL-003).
+			fmt.Fprintf(os.Stderr,
+				"[log] redis stream consumer xack err: %v\n", err)
+		}
+	}
+}
+
+func (c *RedisStreamConsumer) runAutoClaimLoop(ctx context.Context) {
+	defer c.wg.Done()
+
+	ticker := time.NewTicker(c.opts.AutoClaimInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.runAutoClaimOnce(ctx)
+		}
+	}
+}
+
+func (c *RedisStreamConsumer) runAutoClaimOnce(ctx context.Context) {
+	start := "0-0"
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		messages, next, err := c.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+			Stream:   c.streamCfg.StreamKey,
+			Group:    c.opts.GroupName,
+			Consumer: c.opts.ConsumerID,
+			MinIdle:  c.opts.MinIdleTime,
+			Start:    start,
+			Count:    int64(c.opts.BatchSize),
+		}).Result()
+		if err != nil {
+			if !errors.Is(err, redis.Nil) {
+				fmt.Fprintf(os.Stderr,
+					"[log] redis stream consumer xautoclaim err: %v\n", err)
+			}
+			return
+		}
+		if len(messages) > 0 {
+			c.handleStreams(ctx, []redis.XStream{{
+				Stream:   c.streamCfg.StreamKey,
+				Messages: messages,
+			}})
+		}
+		// Continue scanning until next == "0-0" (XAutoClaim's end-of-PEL signal).
+		if next == "0-0" {
+			return
+		}
+		start = next
+	}
+}
+
+func (c *RedisStreamConsumer) runConsumerCleanupLoop(ctx context.Context) {
+	defer c.wg.Done()
+
+	ticker := time.NewTicker(c.opts.ConsumerCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.runConsumerCleanupOnce(ctx)
+		}
+	}
+}
+
+func (c *RedisStreamConsumer) runConsumerCleanupOnce(ctx context.Context) {
+	consumers, err := c.client.XInfoConsumers(ctx, c.streamCfg.StreamKey, c.opts.GroupName).Result()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"[log] redis stream consumer xinfo err: %v\n", err)
+		return
+	}
+	for _, info := range consumers {
+		// Skip self — we are not idle (we're the one running the cleanup).
+		if info.Name == c.opts.ConsumerID {
+			continue
+		}
+		if info.Idle < c.opts.IdleConsumerTTL {
+			continue
+		}
+		// Delete consumers that are both idle AND have no pending entries.
+		// Keeping idle consumers with pending entries lets XAUTOCLAIM
+		// recover them; deleting would lose those PEL records.
+		if info.Pending > 0 {
+			continue
+		}
+		if err := c.client.XGroupDelConsumer(ctx, c.streamCfg.StreamKey, c.opts.GroupName, info.Name).Err(); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"[log] redis stream consumer xgroup delconsumer err name=%s: %v\n", info.Name, err)
+		}
+	}
+}
+
+// parseEntry converts a Redis stream message (raw map[string]any from
+// go-redis) into a typed Entry. Mirrors the producer-side serialization in
+// RedisStreamCore.writeData — any drift between these two functions breaks
+// the system_log pipeline.
+func parseEntry(msg redis.XMessage) (Entry, error) {
+	e := Entry{StreamID: msg.ID}
+
+	if v, ok := msg.Values["ts"].(string); ok && v != "" {
+		ms, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return Entry{}, fmt.Errorf("ts parse: %w", err)
+		}
+		e.Ts = time.UnixMilli(ms)
+	}
+	e.Level, _ = msg.Values["level"].(string)
+	e.Service, _ = msg.Values["service"].(string)
+	e.Source, _ = msg.Values["source"].(string)
+	e.Msg, _ = msg.Values["msg"].(string)
+	e.Host, _ = msg.Values["host"].(string)
+
+	if pl, ok := msg.Values["payload"].(string); ok && pl != "" {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(pl), &m); err == nil {
+			e.Payload = m
+		}
+		// JSON decode failures are tolerated — Payload stays nil. Common
+		// case is the truncation marker `{"_truncated":true}` which decodes
+		// fine; cyclic / corrupt JSON would be observed via missing Payload
+		// and the saver can decide how to handle.
+	}
+	return e, nil
+}
+
+func applyConsumerOptDefaults(opts *ConsumerOpts) {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 100
+	}
+	if opts.FlushMs <= 0 {
+		opts.FlushMs = 500
+	}
+	if opts.MinIdleTime <= 0 {
+		opts.MinIdleTime = 30 * time.Second
+	}
+	if opts.AutoClaimInterval <= 0 {
+		opts.AutoClaimInterval = 10 * time.Second
+	}
+	if opts.IdleConsumerTTL <= 0 {
+		opts.IdleConsumerTTL = 10 * time.Minute
+	}
+	if opts.ConsumerCleanupInterval <= 0 {
+		opts.ConsumerCleanupInterval = 5 * time.Minute
+	}
+}
+
+func isBusyGroup(err error) bool {
+	if err == nil {
+		return false
+	}
+	// go-redis returns a string error for BUSYGROUP; match by substring to
+	// avoid coupling to the redis package's internal error types.
+	return contains(err.Error(), "BUSYGROUP")
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/log/hook/redis_consumer_test.go
+++ b/log/hook/redis_consumer_test.go
@@ -1,0 +1,235 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestRedisStreamConsumer_ParseAndAck end-to-end: producer XADDs entries via
+// the same on-wire format used by RedisStreamCore, the consumer reads, parses
+// into Entry, calls saver, and XACKs. Validates the producer/consumer
+// contract holds — any wire-format drift between sides breaks this.
+func TestRedisStreamConsumer_ParseAndAck(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	streamKey := "system_logs"
+
+	// Producer: write 3 entries directly via go-redis matching the
+	// RedisStreamCore.writeData on-wire format.
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		payload, _ := json.Marshal(map[string]any{
+			"lp":           "prime",
+			"downtime_sec": i * 10,
+		})
+		_, err := rdb.XAdd(ctx, &redis.XAddArgs{
+			Stream: streamKey,
+			Values: map[string]any{
+				"ts":      strconv.FormatInt(now.Add(time.Duration(i)*time.Second).UnixMilli(), 10),
+				"level":   "info",
+				"service": "maker-adapter",
+				"source":  "lp-gateway",
+				"msg":     "connection_restored",
+				"payload": string(payload),
+				"host":    "maker-adapter-pod-1",
+			},
+		}).Result()
+		if err != nil {
+			t.Fatalf("producer xadd: %v", err)
+		}
+	}
+
+	// Saver: capture each batch into a slice for assertions.
+	var (
+		mu      sync.Mutex
+		batches [][]Entry
+		seen    = make(chan struct{}, 8)
+	)
+	saver := func(_ context.Context, batch []Entry) error {
+		mu.Lock()
+		batches = append(batches, batch)
+		mu.Unlock()
+		seen <- struct{}{}
+		return nil
+	}
+
+	consumer, err := NewRedisStreamConsumer(&RedisStreamConfig{
+		Addr:      mr.Addr(),
+		StreamKey: streamKey,
+	}, ConsumerOpts{
+		GroupName:  "system-log-persister",
+		ConsumerID: "test-consumer-1",
+		BatchSize:  10,
+		FlushMs:    50,
+	}, saver)
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+
+	consumerCtx, consumerCancel := context.WithCancel(ctx)
+	if err := consumer.Start(consumerCtx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// XReadGroup with start "$" only sees NEW entries — but our test wrote
+	// before Start, so they're "old" relative to the group offset and will
+	// not appear in XReadGroup. Trigger XAUTOCLAIM by writing a fresh entry
+	// post-Start and waiting.
+	//
+	// Cleaner: re-emit AFTER Start.
+	_, _ = rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: streamKey,
+		Values: map[string]any{
+			"ts":      strconv.FormatInt(now.UnixMilli(), 10),
+			"level":   "warn",
+			"service": "decision-engine",
+			"source":  "risk-engine",
+			"msg":     "extreme_event_triggered",
+			"payload": `{"symbol":"XAUUSD"}`,
+			"host":    "decision-engine-pod-1",
+		},
+	}).Result()
+
+	select {
+	case <-seen:
+	case <-time.After(2 * time.Second):
+		consumerCancel()
+		t.Fatalf("saver did not receive batch within 2s")
+	}
+
+	consumerCancel()
+	if err := consumer.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(batches) == 0 {
+		t.Fatalf("no batches captured")
+	}
+	got := batches[0]
+	if len(got) == 0 {
+		t.Fatalf("first batch was empty")
+	}
+	first := got[0]
+	if first.Service != "decision-engine" {
+		t.Errorf("service=%q, want decision-engine", first.Service)
+	}
+	if first.Source != "risk-engine" {
+		t.Errorf("source=%q, want risk-engine", first.Source)
+	}
+	if first.Level != "warn" {
+		t.Errorf("level=%q, want warn", first.Level)
+	}
+	if first.Msg != "extreme_event_triggered" {
+		t.Errorf("msg=%q, want extreme_event_triggered", first.Msg)
+	}
+	if first.Host != "decision-engine-pod-1" {
+		t.Errorf("host=%q, want decision-engine-pod-1", first.Host)
+	}
+	if first.StreamID == "" {
+		t.Errorf("StreamID should be populated")
+	}
+	if first.Payload["symbol"] != "XAUUSD" {
+		t.Errorf("payload.symbol=%v, want XAUUSD", first.Payload["symbol"])
+	}
+}
+
+// TestRedisStreamConsumer_BadEntryDoesNotBlockBatch validates that a single
+// malformed entry doesn't poison the batch — well-formed siblings still
+// reach the saver.
+func TestRedisStreamConsumer_BadEntryDoesNotBlockBatch(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	streamKey := "system_logs"
+
+	var saverCount int
+	var mu sync.Mutex
+	gotEntry := make(chan struct{}, 1)
+
+	consumer, err := NewRedisStreamConsumer(&RedisStreamConfig{
+		Addr:      mr.Addr(),
+		StreamKey: streamKey,
+	}, ConsumerOpts{
+		GroupName:  "test-group",
+		ConsumerID: "test-consumer-2",
+		BatchSize:  10,
+		FlushMs:    50,
+	}, func(_ context.Context, batch []Entry) error {
+		mu.Lock()
+		saverCount += len(batch)
+		mu.Unlock()
+		select {
+		case gotEntry <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("new consumer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := consumer.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = consumer.Stop() }()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = rdb.Close() }()
+
+	// Mix a malformed (bad ts) entry with a good one.
+	_, _ = rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: streamKey,
+		Values: map[string]any{
+			"ts":      "not-a-number",
+			"level":   "info",
+			"msg":     "bad",
+			"payload": `{}`,
+		},
+	}).Result()
+	_, _ = rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: streamKey,
+		Values: map[string]any{
+			"ts":      strconv.FormatInt(time.Now().UnixMilli(), 10),
+			"level":   "info",
+			"service": "api-server",
+			"msg":     "good",
+			"payload": `{}`,
+			"host":    "h1",
+		},
+	}).Result()
+
+	select {
+	case <-gotEntry:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("saver did not receive entry within 2s")
+	}
+
+	mu.Lock()
+	if saverCount < 1 {
+		t.Errorf("saver should see at least 1 valid entry, got %d", saverCount)
+	}
+	mu.Unlock()
+}

--- a/log/hook/redis_test.go
+++ b/log/hook/redis_test.go
@@ -1,0 +1,266 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func newTestRedisStreamCore(t *testing.T, cfg *RedisStreamConfig, fields map[string]string) (*RedisStreamCore, *miniredis.Miniredis) {
+	t.Helper()
+
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	if cfg == nil {
+		cfg = &RedisStreamConfig{}
+	}
+	cfg.Addr = mr.Addr()
+
+	encConfig := zapcore.EncoderConfig{
+		MessageKey:    "msg",
+		LevelKey:      "level",
+		TimeKey:       "time",
+		EncodeLevel:   zapcore.LowercaseLevelEncoder,
+		EncodeTime:    zapcore.RFC3339NanoTimeEncoder,
+		LineEnding:    zapcore.DefaultLineEnding,
+		EncodeCaller:  zapcore.ShortCallerEncoder,
+	}
+	core, err := NewRedisStreamCore(cfg, "", fields, encConfig)
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	t.Cleanup(func() { _ = core.Close() })
+
+	return core, mr
+}
+
+func readStreamEntries(t *testing.T, mr *miniredis.Miniredis, streamKey string) []map[string]string {
+	t.Helper()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	res, err := rdb.XRange(context.Background(), streamKey, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("xrange: %v", err)
+	}
+	out := make([]map[string]string, 0, len(res))
+	for _, msg := range res {
+		m := make(map[string]string, len(msg.Values))
+		for k, v := range msg.Values {
+			m[k] = toString(v)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if s, ok := v.([]byte); ok {
+		return string(s)
+	}
+	return ""
+}
+
+func waitForStreamLen(t *testing.T, mr *miniredis.Miniredis, streamKey string, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		got, err := rdb.XLen(context.Background(), streamKey).Result()
+		_ = rdb.Close()
+		if err == nil && int(got) >= want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("stream %s did not reach len=%d in time", streamKey, want)
+}
+
+// TestRedisStreamCore_XAddShape validates the producer side wire format
+// (per ADR-0042). Consumer-side parseEntry depends on these exact field
+// names — drift breaks the system_log pipeline.
+func TestRedisStreamCore_XAddShape(t *testing.T) {
+	core, mr := newTestRedisStreamCore(t, &RedisStreamConfig{
+		StreamKey: "system_logs",
+		QPS:       0, // disable throttle for shape test
+	}, map[string]string{
+		"service": "maker-adapter",
+	})
+
+	entry := zapcore.Entry{
+		Time:    time.Date(2026, 5, 6, 12, 34, 56, 0, time.UTC),
+		Level:   zapcore.InfoLevel,
+		Message: "connection_restored",
+	}
+	core.writeData(&CoreData{
+		entry: entry,
+		fields: []zapcore.Field{
+			zap.String("source", "lp-gateway"),
+			zap.String("lp", "prime"),
+			zap.Int("downtime_sec", 192),
+		},
+	})
+
+	waitForStreamLen(t, mr, "system_logs", 1)
+	entries := readStreamEntries(t, mr, "system_logs")
+	if len(entries) != 1 {
+		t.Fatalf("entries=%d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got["service"] != "maker-adapter" {
+		t.Errorf("service=%q, want maker-adapter", got["service"])
+	}
+	if got["source"] != "lp-gateway" {
+		t.Errorf("source=%q, want lp-gateway", got["source"])
+	}
+	if got["level"] != "info" {
+		t.Errorf("level=%q, want info (zap raw)", got["level"])
+	}
+	if got["msg"] != "connection_restored" {
+		t.Errorf("msg=%q, want connection_restored", got["msg"])
+	}
+	if got["host"] == "" {
+		t.Errorf("host should be auto-injected from os.Hostname()")
+	}
+	wantTs := strconv.FormatInt(entry.Time.UnixMilli(), 10)
+	if got["ts"] != wantTs {
+		t.Errorf("ts=%q, want %q", got["ts"], wantTs)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(got["payload"]), &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v\npayload=%s", err, got["payload"])
+	}
+	if payload["lp"] != "prime" {
+		t.Errorf("payload.lp=%v, want prime", payload["lp"])
+	}
+	// JSON numbers decode to float64 by default; assert equivalent value.
+	if got, want := payload["downtime_sec"].(float64), float64(192); got != want {
+		t.Errorf("payload.downtime_sec=%v, want %v", got, want)
+	}
+	// source must NOT appear in payload — it's hoisted to top-level.
+	if _, ok := payload["source"]; ok {
+		t.Errorf("source should not be in payload; got %v", payload)
+	}
+}
+
+// TestRedisStreamCore_PayloadTruncation guards the MaxPayloadBytes hard cap.
+// Oversized payload is REPLACED (not partially truncated) to keep JSON valid.
+func TestRedisStreamCore_PayloadTruncation(t *testing.T) {
+	core, mr := newTestRedisStreamCore(t, &RedisStreamConfig{
+		StreamKey:       "system_logs",
+		MaxPayloadBytes: 100, // tight bound to force truncation
+		QPS:             0,
+	}, nil)
+
+	core.writeData(&CoreData{
+		entry: zapcore.Entry{
+			Time:    time.Now(),
+			Level:   zapcore.WarnLevel,
+			Message: "big_payload",
+		},
+		fields: []zapcore.Field{
+			zap.String("dump", strings.Repeat("x", 500)),
+		},
+	})
+
+	waitForStreamLen(t, mr, "system_logs", 1)
+	entries := readStreamEntries(t, mr, "system_logs")
+	if entries[0]["payload"] != `{"_truncated":true}` {
+		t.Errorf("payload=%q, want {\"_truncated\":true}", entries[0]["payload"])
+	}
+}
+
+// TestRedisStreamCore_FilterDropsKeys guards the CoreConfig.Filter blacklist —
+// listed field keys are silently dropped before serialization.
+func TestRedisStreamCore_FilterDropsKeys(t *testing.T) {
+	core, mr := newTestRedisStreamCore(t, &RedisStreamConfig{
+		StreamKey: "system_logs",
+		CoreConfig: CoreConfig{
+			Filter: []string{"password", "api_key"},
+		},
+		QPS: 0,
+	}, nil)
+
+	// BaseCore.filterFields is invoked from BaseCore.Write before queueing.
+	// We simulate the same path by calling Write directly.
+	if err := core.Write(zapcore.Entry{
+		Time:    time.Now(),
+		Level:   zapcore.InfoLevel,
+		Message: "login",
+	}, []zapcore.Field{
+		zap.String("user", "alice"),
+		zap.String("password", "supersecret"),
+		zap.String("api_key", "AKIA..."),
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	waitForStreamLen(t, mr, "system_logs", 1)
+	entries := readStreamEntries(t, mr, "system_logs")
+
+	var payload map[string]any
+	_ = json.Unmarshal([]byte(entries[0]["payload"]), &payload)
+	if _, ok := payload["password"]; ok {
+		t.Errorf("password should be filtered, got %v", payload)
+	}
+	if _, ok := payload["api_key"]; ok {
+		t.Errorf("api_key should be filtered, got %v", payload)
+	}
+	if payload["user"] != "alice" {
+		t.Errorf("user=%v, want alice", payload["user"])
+	}
+}
+
+// TestRedisStreamCore_ThrottleDrops guards the QPS token-bucket — over-budget
+// entries are dropped silently (with droppedTotal incremented).
+func TestRedisStreamCore_ThrottleDrops(t *testing.T) {
+	core, mr := newTestRedisStreamCore(t, &RedisStreamConfig{
+		StreamKey: "system_logs",
+		QPS:       2, // very tight budget
+	}, nil)
+
+	for i := 0; i < 10; i++ {
+		core.writeData(&CoreData{
+			entry: zapcore.Entry{
+				Time:    time.Now(),
+				Level:   zapcore.InfoLevel,
+				Message: "burst",
+			},
+		})
+	}
+
+	// Wait for whatever entries pass the bucket to land in the stream.
+	time.Sleep(150 * time.Millisecond)
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	got, err := rdb.XLen(context.Background(), "system_logs").Result()
+	if err != nil {
+		t.Fatalf("xlen: %v", err)
+	}
+	if got > 3 {
+		t.Errorf("expected <=3 entries through bucket cap=2, got %d", got)
+	}
+	if core.DroppedTotal() == 0 {
+		t.Errorf("expected DroppedTotal > 0, got 0")
+	}
+}

--- a/log/kratos/kratos.go
+++ b/log/kratos/kratos.go
@@ -13,10 +13,26 @@ type logger struct {
 	*tklog.Logger
 }
 
+// NewZapLog returns a Kratos log.Logger backed by tklog (zap).
+//
+// Two call patterns are supported in Log() below:
+//   - hkjojo Helper (odd-length kvs, tail msgkey)
+//   - Kratos standard log.Helper / framework (even-length kvs, leading "msg" pair)
+//
+// Caller skip is applied here so that log entries report the user code line,
+// not this adapter file. The skip value (3) is calibrated for the Kratos
+// log.Helper.Infow path (helper.go → kratos.logger.Log → tklog.Logger.Info),
+// matching the previous TradePass pkg/logger compat shim's behavior. Direct
+// framework logs (no Helper wrapper) report 1-2 frames too deep — accepted
+// trade-off, framework log volume is low.
 func NewZapLog(cfg *tklog.Config, opts ...tklog.Option) (log.Logger, error) {
 	tklogger, err := tklog.New(cfg, opts...)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg != nil && cfg.Caller {
+		tklogger.Logger = tklogger.Logger.WithOptions(zap.AddCallerSkip(3))
 	}
 
 	return &logger{Logger: tklogger}, nil
@@ -24,7 +40,17 @@ func NewZapLog(cfg *tklog.Config, opts ...tklog.Option) (log.Logger, error) {
 
 var _ log.Logger = (*logger)(nil)
 
-// Log impl kratos log, but try to find a msg key
+// Log impl kratos log, supporting both call patterns:
+//   - Odd-length kvs (hkjojo Helper): tail-position msgkey-typed value carries
+//     the message. Helper.Infow appends a msgkey at the end.
+//   - Even-length kvs (Kratos standard log.Helper / framework): leading
+//     ("msg", string) pair carries the message. log.Helper.Infow does
+//     append(kvs, "msg", msg) to construct kvs, but Kratos framework code
+//     also commonly emits ("msg", X, k1, v1, ...) directly via logger.Log.
+//
+// Without the even-length branch, the leading "msg" pair would be emitted as
+// a regular zap.Field while the zap encoder also writes its own MessageKey:"msg"
+// for the empty Entry.Message → produces double-msg key in JSON output.
 func (l *logger) Log(level log.Level, kvs ...interface{}) error {
 	ll := len(kvs)
 	if ll == 0 {
@@ -38,7 +64,7 @@ func (l *logger) Log(level log.Level, kvs ...interface{}) error {
 	)
 
 	if (ll & 1) == 1 {
-		// find msgkey from reverse sort
+		// odd-length: hkjojo Helper convention — find msgkey at tail
 		for i := ll - 1; i >= 0; i-- {
 			msg, ok = kvs[i].(msgkey)
 			if ok {
@@ -49,6 +75,14 @@ func (l *logger) Log(level log.Level, kvs ...interface{}) error {
 
 		if msg == "" {
 			kvs = append(kvs, "invalid keyvals")
+		}
+	} else if ll >= 2 {
+		// even-length: Kratos framework convention — leading ("msg", X) pair
+		if k, kok := kvs[0].(string); kok && k == "msg" {
+			if v, vok := kvs[1].(string); vok {
+				msg = msgkey(v)
+				kvs = kvs[2:]
+			}
 		}
 	}
 
@@ -73,6 +107,13 @@ func (l *logger) Log(level log.Level, kvs ...interface{}) error {
 	return nil
 }
 
+// Sync flushes buffered log entries.
+//
+// Calls the embedded tklog.Logger.Sync (which delegates to the underlying
+// *zap.Logger.Sync via tklog.Logger's own embedded *zap.Logger). The previous
+// implementation `return l.Sync()` recursed back into this very method —
+// any caller of Sync() would hit a stack overflow. Caught during the
+// system_log via Redis stream rollout (ADR-0042).
 func (l *logger) Sync() error {
-	return l.Sync()
+	return l.Logger.Sync()
 }

--- a/log/kratos/kratos_test.go
+++ b/log/kratos/kratos_test.go
@@ -1,0 +1,135 @@
+package kratos
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	klog "github.com/go-kratos/kratos/v2/log"
+
+	tklog "github.com/hkjojo/go-toolkits/log/v2"
+)
+
+// TestLog_KratosFrameworkEvenKvs_NoDoubleMsg guards against the cosmetic bug
+// where even-length kvs starting with ("msg", X) emitted a double "msg" key
+// in JSON output. Before the H1 fix, framework log of the form
+//
+//	logger.Log(InfoLevel, "msg", "[HTTP] server listening", "k", "v")
+//
+// produced {"msg":"","msg":"[HTTP] server listening","k":"v"}.
+func TestLog_KratosFrameworkEvenKvs_NoDoubleMsg(t *testing.T) {
+	line := captureSingleLogLine(t, func(logger klog.Logger) {
+		_ = logger.Log(klog.LevelInfo,
+			"msg", "[HTTP] server listening on: [::]:8080",
+			"k", "v",
+		)
+	})
+
+	if got := strings.Count(line, `"msg"`); got != 1 {
+		t.Fatalf("expected single msg key, got %d in line: %s", got, line)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["msg"] != "[HTTP] server listening on: [::]:8080" {
+		t.Errorf("msg=%q, want HTTP listening message", m["msg"])
+	}
+	if m["k"] != "v" {
+		t.Errorf("k=%v, want v", m["k"])
+	}
+}
+
+// TestLog_HkjojoHelperOddKvs_TailMsgkey covers the original odd-length kvs
+// path (Helper.Infow appends a msgkey at the tail) — must continue to work
+// after the H1 even-kvs branch was added.
+func TestLog_HkjojoHelperOddKvs_TailMsgkey(t *testing.T) {
+	line := captureSingleLogLine(t, func(logger klog.Logger) {
+		_ = logger.Log(klog.LevelInfo,
+			"k", "v",
+			msgkey("api-server started"),
+		)
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatalf("unmarshal: %v\nline=%s", err, line)
+	}
+	if m["msg"] != "api-server started" {
+		t.Errorf("msg=%q, want api-server started", m["msg"])
+	}
+	if m["k"] != "v" {
+		t.Errorf("k=%v, want v", m["k"])
+	}
+}
+
+// TestSync_NoRecursion guards against the Sync infinite-recursion bug. Before
+// H1 fix, `func (l *logger) Sync() error { return l.Sync() }` would recurse
+// into itself forever; any caller of Sync hit a stack-overflow panic.
+func TestSync_NoRecursion(t *testing.T) {
+	logger, err := NewZapLog(&tklog.Config{
+		Level:  "info",
+		Format: "json",
+	})
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+
+	syncer, ok := logger.(klog.Logger)
+	if !ok {
+		t.Fatalf("logger does not implement klog.Logger")
+	}
+	type syncable interface {
+		Sync() error
+	}
+	if s, ok := syncer.(syncable); ok {
+		// If the recursion is back, this call stack-overflows; the panic is
+		// caught by the test framework. We don't actually care about the
+		// return value (zap stdout sync sometimes errors with EINVAL),
+		// only that the call returns within reasonable time/depth.
+		_ = s.Sync()
+	}
+}
+
+// captureSingleLogLine builds a logger that writes to an in-memory buffer,
+// invokes the provided func, and returns the (single) JSON log line emitted.
+func captureSingleLogLine(t *testing.T, emit func(logger klog.Logger)) string {
+	t.Helper()
+
+	// Redirect stdout to a pipe; tklog Config.DisableStdout=false is the
+	// default path, so this works without modifying tklog internals.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	stdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = stdout }()
+
+	logger, err := NewZapLog(&tklog.Config{
+		Level:  "info",
+		Format: "json",
+	})
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+
+	emit(logger)
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	line := strings.TrimSpace(buf.String())
+	// In case of multi-line output, take the first JSON-shaped line.
+	if idx := strings.Index(line, "\n"); idx >= 0 {
+		line = line[:idx]
+	}
+	return line
+}

--- a/log/log.go
+++ b/log/log.go
@@ -31,9 +31,10 @@ type Config struct {
 	ForbidLevel   bool                  `json:"forbid_level"`
 	Caller        bool                  `json:"caller"`
 	Prefix        string                `json:"prefix"`
-	Kafka         *hook.KafkaConfig     `json:"kafka"`
-	WebHook       []*hook.WebHookConfig `json:"webhook"`
-	RotateDay     int                   `json:"rotate_day"`
+	Kafka         *hook.KafkaConfig       `json:"kafka"`
+	WebHook       []*hook.WebHookConfig   `json:"webhook"`
+	Redis         *hook.RedisStreamConfig `json:"redis"`
+	RotateDay     int                     `json:"rotate_day"`
 }
 
 func (c *Config) Metric() *Config {
@@ -234,6 +235,14 @@ func New(config *Config, opts ...Option) (*Logger, error) {
 
 	if config.Kafka != nil {
 		core, err := hook.NewKafkaCore(config.Kafka, config.Prefix, config.Fields, encoderConfig)
+		if err != nil {
+			return nil, err
+		}
+		cores = append(cores, core)
+	}
+
+	if config.Redis != nil {
+		core, err := hook.NewRedisStreamCore(config.Redis, config.Prefix, config.Fields, encoderConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
新增 producer/consumer 双端 Redis stream 集成,用于跨服务运行事件汇集 (参 TradePass Edge 项目 ADR-0042 + system_log plan)。

新增:
- hook/redis.go RedisStreamCore + RedisStreamConfig:zap core 实现, XADD 每条 log entry 到 stream,固定字段 shape (ts/level/service/ source/msg/payload/host)。host 取 os.Hostname() 自动注入,多副本去重。 内置 token bucket QPS throttle (default 50/s),内置 MaxPayloadBytes 硬 cap (default 4096) 防业务方误 dump 大对象。失败模式跟 KafkaCore 一致 — startup ping 失败警告但不致命,运行期 XAdd 错误打 stderr 不阻 塞 logger。
- hook/redis_consumer.go RedisStreamConsumer + Entry + SaverFunc:从同 stream 读 + 解析 + 调用业务方 saver 落库 + XACK。三协程并发 — main loop / autoclaim loop / consumer cleanup loop,context 协调退出。
- log.go Config 加 Redis 字段,New() cores 列表 append RedisStreamCore (跟 Kafka 对称模式)。
- 新增 dep:redis/go-redis/v9 v9.18.0 + miniredis/v2 v2.37.0 (test only)。
- README 加用法 + wire format 说明。

修复:
- kratos/kratos.go cosmetic bug:Log() 偶数 kvs 不识别 ("msg", X) 首对 → JSON 输出双 msg key (`{"msg":"","msg":"actual"}`)。Kratos framework 自身打 log (`[HTTP] server listening on: ...`) 走这条路径,长期被 TradePass pkg/logger compat shim 绕过。本 commit 修源,允许 shim 删除。
- kratos/kratos.go Sync 无限递归:`return l.Sync()` 调用自身,任何 Sync 调用 stack overflow。改为 `l.Logger.Sync()` 调用嵌入 *tklog.Logger 的 Sync。pkg/logger 之前自实现 Sync 绕过,删 shim 后必须修。
- NewZapLog 应用 zap.AddCallerSkip(3) (cfg.Caller=true 时),让 caller 报到业务代码,而非 kratos.go 本身。沿用 TradePass pkg/logger 标定值。

测试:
- kratos/kratos_test.go:双 msg / Sync 递归 / odd-kvs Helper 路径回归
- hook/redis_test.go:XADD 字段 shape / payload 截断 / Filter 黑名单 / QPS 节流 (用 miniredis)
- hook/redis_consumer_test.go:producer 写 → consumer 解析 → saver 收 到 typed Entry / 单条坏 entry 不阻塞 batch (用 miniredis)
- 全过 (`go test ./kratos/... ./hook/... -count=1` exit=0,除 pre-existing TestKafka 需要真实 Kafka broker 不通过)

不在本 commit 范围:tag log/v2.3.0 — 等 reviewer 看完再发版。