### PR TITLE
feat(apptools): add WithViews and RequestSecondsHistogramView

### DIFF
--- a/apptools/metric/metric.go
+++ b/apptools/metric/metric.go
@@ -68,6 +68,9 @@ func NewMetricProvider(ops ...Option) (metric.MeterProvider, func(), error) {
 		// 关联资源信息，所有 metric 都会包含这些元数据
 		sdkmetric.WithResource(res),
 	}
+	for _, view := range globalConfig.Views {
+		opts = append(opts, sdkmetric.WithView(view))
+	}
 
 	mp := sdkmetric.NewMeterProvider(opts...)
 
@@ -148,6 +151,7 @@ type Config struct {
 	DefaultPrefix string        // 默认指标前缀
 	Debug         bool          // 调试模式
 	InitCallback  func()        // 初始化回调函数
+	Views         []sdkmetric.View
 }
 
 // Option 配置选项函数
@@ -200,4 +204,23 @@ func WithInitCallback(fn func()) Option {
 	return func(cfg *Config) {
 		cfg.InitCallback = fn
 	}
+}
+
+// WithViews configures OpenTelemetry SDK metric views.
+func WithViews(views ...sdkmetric.View) Option {
+	return func(cfg *Config) {
+		cfg.Views = append(cfg.Views, views...)
+	}
+}
+
+// RequestSecondsHistogramView returns explicit buckets for request duration histograms.
+func RequestSecondsHistogramView() sdkmetric.View {
+	return sdkmetric.NewView(
+		sdkmetric.Instrument{Name: "*_requests_seconds"},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			},
+		},
+	)
 }

--- a/apptools/metric/metric_test.go
+++ b/apptools/metric/metric_test.go
@@ -1,0 +1,45 @@
+package metric
+
+import (
+	"reflect"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestRequestSecondsHistogramView(t *testing.T) {
+	stream, ok := RequestSecondsHistogramView()(sdkmetric.Instrument{Name: "td_server_requests_seconds"})
+	if !ok {
+		t.Fatal("expected request seconds view to match")
+	}
+
+	agg, ok := stream.Aggregation.(sdkmetric.AggregationExplicitBucketHistogram)
+	if !ok {
+		t.Fatalf("aggregation = %T, want AggregationExplicitBucketHistogram", stream.Aggregation)
+	}
+
+	want := []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+	if !reflect.DeepEqual(agg.Boundaries, want) {
+		t.Fatalf("boundaries = %v, want %v", agg.Boundaries, want)
+	}
+
+	if _, ok := RequestSecondsHistogramView()(sdkmetric.Instrument{Name: "td_transaction_duration_seconds"}); ok {
+		t.Fatal("request seconds view should not match non-request histogram")
+	}
+}
+
+func TestWithViews(t *testing.T) {
+	cfg := &Config{}
+
+	// 单次调用接收变长参数：两个 view 都应入列。
+	WithViews(RequestSecondsHistogramView(), RequestSecondsHistogramView())(cfg)
+	if len(cfg.Views) != 2 {
+		t.Fatalf("after first WithViews: len = %d, want 2", len(cfg.Views))
+	}
+
+	// 重复调用应累加而非覆盖（防回归：误改成 cfg.Views = views 会让先注册的视图被丢弃）。
+	WithViews(RequestSecondsHistogramView())(cfg)
+	if len(cfg.Views) != 3 {
+		t.Fatalf("after second WithViews: len = %d, want 3 (append, not replace)", len(cfg.Views))
+	}
+}


### PR DESCRIPTION
给 apptools/metric 加两个 helper，让应用服务可以覆盖默认的 histogram bucket 边界：

- `WithViews(views ...sdkmetric.View) Option`：append 式 Option，让外部能给 MeterProvider 注入任意 OTel View，多次调用累加不互相覆盖。
- `RequestSecondsHistogramView()`：预设 View，匹配 `*_requests_seconds` 通配符，应用 Prometheus client_golang 的 DefBuckets `[0.005, 0.01, ..., 10]`。

## 为什么要做

Kratos `metrics.Server` / `metrics.Client` 中间件产生的 `td_server_requests_seconds` / `td_client_requests_seconds` 单位是秒，但 OTel SDK 默认 bucket 是给毫秒级设计的（0...10000 步进）。线上 99% 请求都落进 `[0, 5]` 这个桶，`histogram_quantile(0.99, ...)` 算出来永远是 ~4.95s，跟真实延迟无关。

应用层因为这两个 instrument 是 middleware 内部建的，没法直接 `WithExplicitBucketBoundaries`，只能在 MeterProvider 配置时用 View 拦截，所以加 `WithViews`。

## 后向兼容

完全兼容。没改任何现有函数签名，`Config` 加了一个新字段但零值（nil slice）下 for-range 是空操作，不传 `WithViews` 的调用方行为不变。